### PR TITLE
Reform colors for 'Prevent display stretching' example

### DIFF
--- a/examples/prevent_display_stretching.py
+++ b/examples/prevent_display_stretching.py
@@ -53,8 +53,8 @@ screen = pg.display.set_mode(RESOLUTION)
 # Render message onto a surface
 pg.font.init()
 font = pg.font.Font(None, 36)
-msg_surf = font.render(msg, 1, pg.Color("green"))
-res_surf = font.render("Intended resolution: %ix%i" % RESOLUTION, 1, pg.Color("green"))
+msg_surf = font.render(msg, 1, "green")
+res_surf = font.render("Intended resolution: %ix%i" % RESOLUTION, 1, "green")
 
 # Control loop
 running = True
@@ -66,12 +66,12 @@ while running:
         if event.type == pg.QUIT:
             running = False
 
-    screen.fill(pg.Color("black"))
+    screen.fill("black")
 
     # Draw lines which will be blurry if the window is stretched
     # or clear if the window is not stretched.
-    pg.draw.line(screen, pg.Color("white"), (0, counter), (RESOLUTION[0] - 1, counter))
-    pg.draw.line(screen, pg.Color("white"), (counter, 0), (counter, RESOLUTION[1] - 1))
+    pg.draw.line(screen, "white", (0, counter), (RESOLUTION[0] - 1, counter))
+    pg.draw.line(screen, "white", (counter, 0), (counter, RESOLUTION[1] - 1))
 
     # Blit message onto screen surface
     msg_blit_rect = screen.blit(msg_surf, (0, 0))

--- a/examples/prevent_display_stretching.py
+++ b/examples/prevent_display_stretching.py
@@ -16,6 +16,12 @@ Vista and newer).
 
 """
 
+# game constants
+# colors are specified in the colordict.py file
+GREENCOLOR = "green"
+BLACKCOLOR = "black"
+WHITECOLOR = "white"
+
 # Ensure that the computer is running Windows Vista or newer
 import os
 import sys
@@ -53,8 +59,8 @@ screen = pg.display.set_mode(RESOLUTION)
 # Render message onto a surface
 pg.font.init()
 font = pg.font.Font(None, 36)
-msg_surf = font.render(msg, 1, "green")
-res_surf = font.render("Intended resolution: %ix%i" % RESOLUTION, 1, "green")
+msg_surf = font.render(msg, 1, GREENCOLOR)
+res_surf = font.render("Intended resolution: %ix%i" % RESOLUTION, 1, GREENCOLOR)
 
 # Control loop
 running = True
@@ -66,12 +72,12 @@ while running:
         if event.type == pg.QUIT:
             running = False
 
-    screen.fill("black")
+    screen.fill(BLACKCOLOR)
 
     # Draw lines which will be blurry if the window is stretched
     # or clear if the window is not stretched.
-    pg.draw.line(screen, "white", (0, counter), (RESOLUTION[0] - 1, counter))
-    pg.draw.line(screen, "white", (counter, 0), (counter, RESOLUTION[1] - 1))
+    pg.draw.line(screen, WHITECOLOR, (0, counter), (RESOLUTION[0] - 1, counter))
+    pg.draw.line(screen, WHITECOLOR, (counter, 0), (counter, RESOLUTION[1] - 1))
 
     # Blit message onto screen surface
     msg_blit_rect = screen.blit(msg_surf, (0, 0))


### PR DESCRIPTION
Issue: pygame#2860

Updated the use of colors in the prevent_display_stretching example as a result of pygame 2.0 changes.